### PR TITLE
Add basic Netlify functions and 404 page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.netlify/

--- a/functions/make-call.js
+++ b/functions/make-call.js
@@ -1,0 +1,32 @@
+const twilio = require('twilio');
+
+exports.handler = async (event) => {
+  let data;
+  try {
+    data = JSON.parse(event.body || '{}');
+  } catch (err) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON' })
+    };
+  }
+
+  const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+
+  try {
+    const call = await client.calls.create({
+      url: data.url || 'http://demo.twilio.com/docs/voice.xml',
+      to: data.to,
+      from: process.env.TWILIO_PHONE_NUMBER
+    });
+    return {
+      statusCode: 200,
+      body: JSON.stringify(call)
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error.message })
+    };
+  }
+};

--- a/functions/send-sms.js
+++ b/functions/send-sms.js
@@ -1,0 +1,32 @@
+const twilio = require('twilio');
+
+exports.handler = async (event) => {
+  let data;
+  try {
+    data = JSON.parse(event.body || '{}');
+  } catch (err) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON' })
+    };
+  }
+
+  const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+
+  try {
+    const message = await client.messages.create({
+      body: data.message,
+      to: data.to,
+      from: process.env.TWILIO_PHONE_NUMBER
+    });
+    return {
+      statusCode: 200,
+      body: JSON.stringify(message)
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error.message })
+    };
+  }
+};

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>404 - Page Not Found</title>
+</head>
+<body>
+  <h1>Page Not Found</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ignore Node.js dependencies and environment files
- add a simple 404 page
- add Netlify functions for making calls and sending SMS with JSON parsing guard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68506e011f548323b324c658b9077514